### PR TITLE
functional TCP implementation; example but no tests

### DIFF
--- a/examples/tcp-client.p6
+++ b/examples/tcp-client.p6
@@ -2,7 +2,7 @@
 
 use v6.c;
 use lib "lib";
-use Net::OSC::TCP;
+use Net::OSC::Transport::TCP;
 use Net::OSC::Message;
 
 sub MAIN(:$use-slip = True) {

--- a/examples/tcp-client.p6
+++ b/examples/tcp-client.p6
@@ -1,0 +1,44 @@
+#!/usr/bin/env perl6
+
+use v6.c;
+use lib "lib";
+use Net::OSC::TCP;
+use Net::OSC::Message;
+
+sub MAIN(:$use-slip = True) {
+
+  # Create a TCP socket
+  my $tcp-client = IO::Socket::INET.new(:host<127.0.0.1>, :port(55555));
+
+  my Net::OSC::Message $message .= new(
+    :path</a>
+    :args(0, 2.3456789, 'abc')
+    :is64bit(False)
+  );
+
+  loop {
+    if $use-slip {
+      send-slip($tcp-client, $message);
+    }
+    else {
+      send-lp($tcp-client, $message);
+    }
+
+    sleep 0.8;
+
+    $message = $use-slip ?? recv-slip($tcp-client) !! recv-lp($tcp-client);
+
+    my @args = $message.args;
+    @args[1] += 0.00010231;
+    say 'incrementing argument 1 to ', @args[1];
+
+    $message = Net::OSC::Message.new(
+      :path($message.path)
+      :args(@args)
+      :is64bit(False)
+    );
+
+    sleep 0.2;
+
+  }
+}

--- a/examples/tcp-server.p6
+++ b/examples/tcp-server.p6
@@ -1,0 +1,33 @@
+#!/usr/bin/env perl6
+
+use v6.c;
+use lib "lib";
+use Net::OSC::TCP;
+use Net::OSC::Message;
+
+sub MAIN(:$use-slip = True) {
+
+  my $tcp-server = IO::Socket::INET.new(:localhost<127.0.0.1>, :localport(55555), :listen(True));
+
+  while my $connection = $tcp-server.accept() {
+    loop {
+      my $message = $use-slip ?? recv-slip($connection) !! recv-lp($connection);
+
+      my @args = $message.args;
+      say 'incrementing argument 0 to ', ++@args[0];
+
+      $message = Net::OSC::Message.new(
+        :path($message.path)
+        :args(@args)
+        :is64bit(False)
+      );
+
+      if $use-slip {
+        send-slip($connection, $message);
+      }
+      else {
+        send-lp($connection, $message);
+      }
+    }
+  }
+}

--- a/examples/tcp-server.p6
+++ b/examples/tcp-server.p6
@@ -2,7 +2,7 @@
 
 use v6.c;
 use lib "lib";
-use Net::OSC::TCP;
+use Net::OSC::Transport::TCP;
 use Net::OSC::Message;
 
 sub MAIN(:$use-slip = True) {

--- a/lib/Net/OSC/TCP.pm6
+++ b/lib/Net/OSC/TCP.pm6
@@ -1,0 +1,53 @@
+use v6;
+unit module Net::OSC::TCP;
+use Net::OSC::Message;
+
+# Length-prefixed message framing
+#
+
+sub send-lp(IO::Socket::INET $socket, Net::OSC::Message $message) is export {
+  my Int $i = $message.package.elems;
+  $socket.write(Buf.new(($i+>24) +& 0xFF, ($i+>16) +& 0xFF, ($i+>8) +& 0xFF, $i +& 0xFF));
+  $socket.write($message.package);
+}
+
+sub recv-lp(IO::Socket::INET $socket) returns Net::OSC::Message is export {
+  my Buf $p = $socket.read(4);
+  my Buf $b = $socket.read(($p[0]+<24) +| ($p[1]+<16) +| ($p[2]+<8) +| $p[3]);
+  Net::OSC::Message.unpackage($b)
+}
+
+
+# SLIP message framing
+#
+# see https://en.wikipedia.org/wiki/Serial_Line_Internet_Protocol
+#
+
+sub send-slip(IO::Socket::INET $socket, Net::OSC::Message $message) is export {
+  my @list = [];
+  for $message.package.list {
+    when 0xC0 { @list.append: 0xDB, 0xDC; }
+    when 0xDB { @list.append: 0xDB, 0xDD; }
+    default   { @list.append: $_; }
+  }
+  @list.append: 0xC0;
+  $socket.write(Buf.new(@list));
+}
+
+sub recv-slip(IO::Socket::INET $socket) returns Net::OSC::Message is export {
+  my @list = [];
+  loop {
+    given $socket.read(1)[0] {
+      when 0xC0 { last; }
+      when 0xDB {
+        given $socket.read(1)[0] {
+          when 0xDC { @list.append: 0xC0; }
+          when 0xDD { @list.append: 0xDB; }
+          default { die 'this should never happen'; }
+        }
+      }
+      default { @list.append: $_; }
+    }
+  }
+  Net::OSC::Message.unpackage(Buf.new(@list));
+}

--- a/lib/Net/OSC/Transport/TCP.pm6
+++ b/lib/Net/OSC/Transport/TCP.pm6
@@ -2,16 +2,25 @@ use v6;
 unit module Net::OSC::TCP;
 use Net::OSC::Message;
 
-# Length-prefixed message framing
+#
+# When doing OSC over TCP, we have to do some sort of framing so that we can tell
+# where one OSC packet ends and the next begins. There's many ways to do this
+# framing, but the two methods below are commonly used.
+#
+# See http://forum.renoise.com/index.php/topic/43159-osc-via-tcp-has-no-framing
 #
 
+# Length-prefixed message framing
+#
+# This is used by SuperCollider.
+#
 sub send-lp(IO::Socket::INET $socket, Net::OSC::Message $message) is export {
   my Int $i = $message.package.elems;
   $socket.write(Buf.new(($i+>24) +& 0xFF, ($i+>16) +& 0xFF, ($i+>8) +& 0xFF, $i +& 0xFF));
   $socket.write($message.package);
 }
 
-sub recv-lp(IO::Socket::INET $socket) returns Net::OSC::Message is export {
+sub recv-lp(IO::Socket::INET $socket --> Net::OSC::Message) is export {
   my Buf $p = $socket.read(4);
   my Buf $b = $socket.read(($p[0]+<24) +| ($p[1]+<16) +| ($p[2]+<8) +| $p[3]);
   Net::OSC::Message.unpackage($b)
@@ -21,6 +30,8 @@ sub recv-lp(IO::Socket::INET $socket) returns Net::OSC::Message is export {
 # SLIP message framing
 #
 # see https://en.wikipedia.org/wiki/Serial_Line_Internet_Protocol
+#
+# This is used by PureData.
 #
 
 sub send-slip(IO::Socket::INET $socket, Net::OSC::Message $message) is export {
@@ -34,7 +45,7 @@ sub send-slip(IO::Socket::INET $socket, Net::OSC::Message $message) is export {
   $socket.write(Buf.new(@list));
 }
 
-sub recv-slip(IO::Socket::INET $socket) returns Net::OSC::Message is export {
+sub recv-slip(IO::Socket::INET $socket --> Net::OSC::Message) is export {
   my @list = [];
   loop {
     given $socket.read(1)[0] {

--- a/lib/Net/OSC/Transport/TCP.pm6
+++ b/lib/Net/OSC/Transport/TCP.pm6
@@ -1,5 +1,5 @@
 use v6;
-unit module Net::OSC::TCP;
+unit module Net::OSC::Transport::TCP;
 use Net::OSC::Message;
 
 #

--- a/t/tcp.t
+++ b/t/tcp.t
@@ -1,0 +1,63 @@
+#!/usr/bin/env perl6
+use v6.c;
+use Test;
+
+# plan 3;
+
+use-ok 'Net::OSC::Transport::TCP';
+use Net::OSC::Transport::TCP;
+
+use-ok 'Net::OSC::Message';
+use Net::OSC::Message;
+
+my Net::OSC::Message $t .= new(
+  :path</a>
+  :args(0, 2.3456789, 'abc')
+  :is64bit(False)
+);
+
+todo 'this hangs; it is broken';
+pass;
+exit 0;
+
+#
+# XXX FIXME: started this attempt at a test, but i'm doing something wrong --kybr
+#
+
+{
+  # promise that sends a message
+  my $slip-sender = start {
+    my $tcp-client = IO::Socket::INET.new(:host<127.0.0.1>, :port(55556));
+    diag 'waiting to send....';
+    sleep 0.5;
+    send-slip($tcp-client, $t);
+  };
+
+  diag 'creating TCP listener...';
+  my $tcp-server = IO::Socket::INET.new(:localhost<127.0.0.1>, :localport(55556), :listen(True));
+  my $connection = $tcp-server.accept();
+  my $m = recv-slip($connection);
+  await $slip-sender;
+
+  #ok $t.args[0] == $m.args[0];
+}
+
+sleep 0.5;
+
+{
+  # promise that sends a message
+  my $lp-sender = start {
+    my $tcp-client = IO::Socket::INET.new(:host<127.0.0.1>, :port(55555));
+    diag 'waiting to send....';
+    sleep 0.5;
+    send-lp($tcp-client, $t);
+  };
+
+  diag 'creating TCP listener...';
+  my $tcp-server = IO::Socket::INET.new(:localhost<127.0.0.1>, :localport(55555), :listen(True));
+  my $connection = $tcp-server.accept();
+  my $m = recv-lp($connection);
+  await $lp-sender;
+
+  #ok $t.args[0] == $m.args[0];
+}

--- a/t/tcp.t
+++ b/t/tcp.t
@@ -2,12 +2,12 @@
 use v6.c;
 use Test;
 
-# plan 3;
+plan 3;
 
 use-ok 'Net::OSC::Transport::TCP';
 use Net::OSC::Transport::TCP;
 
-use-ok 'Net::OSC::Message';
+#use-ok 'Net::OSC::Message';
 use Net::OSC::Message;
 
 my Net::OSC::Message $t .= new(
@@ -15,14 +15,6 @@ my Net::OSC::Message $t .= new(
   :args(0, 2.3456789, 'abc')
   :is64bit(False)
 );
-
-todo 'this hangs; it is broken';
-pass;
-exit 0;
-
-#
-# XXX FIXME: started this attempt at a test, but i'm doing something wrong --kybr
-#
 
 {
   # promise that sends a message
@@ -39,10 +31,10 @@ exit 0;
   my $m = recv-slip($connection);
   await $slip-sender;
 
-  #ok $t.args[0] == $m.args[0];
+  is $t.args[0], $m.args[0], "Slip TCP message matches presend message";
 }
 
-sleep 0.5;
+#sleep 0.5;
 
 {
   # promise that sends a message
@@ -59,5 +51,5 @@ sleep 0.5;
   my $m = recv-lp($connection);
   await $lp-sender;
 
-  #ok $t.args[0] == $m.args[0];
+  is $t.args[0], $m.args[0], "Length-prefixed TCP message matches presend message";
 }

--- a/t/tcp.t
+++ b/t/tcp.t
@@ -2,7 +2,7 @@
 use v6.c;
 use Test;
 
-plan 9;
+plan 11;
 
 use-ok 'Net::OSC::Transport::TCP';
 use Net::OSC::Transport::TCP;
@@ -24,8 +24,10 @@ my $slip-test = start {
   send-slip($client, $t); # maybe we should catch an exception here?
   my $connection = $server.accept();
   ok $connection, 'Server accepted connection';
-  my $m = send-slip($connection, $t);
-  ok ($t.args Z $m.args).map({ $_[0] =~= $_[1] }).all, 'Received message matches sent message';
+  my $m = recv-slip($connection);
+
+  # XXX why does this not seem to run?
+  ok ($t.args Z $m.args).map({ $_[0] == $_[1] }).all, 'Received message matches sent message';
 };
 await Promise.anyof($slip-test, Promise.in(1).then({ flunk "FAILURE: Timed out!"; }));
 ok $slip-test, 'Passing an OSC message with SLIP+TCP worked.';
@@ -38,7 +40,9 @@ my $lp-test = start {
   send-lp($client, $t); # maybe we should catch an exception here?
   my $connection = $server.accept();
   ok $connection, 'Server accepted connection';
-  my $m = send-lp($connection, $t);
+  my $m = recv-lp($connection);
+
+  # XXX why does this not seem to run?
   ok ($t.args Z $m.args).map({ $_[0] =~= $_[1] }).all, 'Received message matches sent message';
 };
 await Promise.anyof($lp-test, Promise.in(1).then({ flunk "FAILURE: Timed out!"; }));

--- a/t/tcp.t
+++ b/t/tcp.t
@@ -12,7 +12,7 @@ use Net::OSC::Message;
 
 my Net::OSC::Message $t .= new(
   :path</a>
-  :args(0, 2.3456789, 'abc')
+  :args(0, 2.5, 'abc')
   :is64bit(False)
 );
 
@@ -26,8 +26,9 @@ my $slip-test = start {
   ok $connection, 'Server accepted connection';
   my $m = recv-slip($connection);
 
-  # XXX why does this not seem to run?
-  ok ($t.args Z $m.args).map({ $_[0] == $_[1] }).all, 'Received message matches sent message';
+  is $t.args, $m.args, 'Received message matches sent message';
+
+  CATCH { warn .Str }
 };
 await Promise.anyof($slip-test, Promise.in(1).then({ flunk "FAILURE: Timed out!"; }));
 ok $slip-test, 'Passing an OSC message with SLIP+TCP worked.';
@@ -42,8 +43,9 @@ my $lp-test = start {
   ok $connection, 'Server accepted connection';
   my $m = recv-lp($connection);
 
-  # XXX why does this not seem to run?
-  ok ($t.args Z $m.args).map({ $_[0] =~= $_[1] }).all, 'Received message matches sent message';
+  is $t.args, $m.args, 'Received message matches sent message';
+
+  CATCH { warn .Str }
 };
 await Promise.anyof($lp-test, Promise.in(1).then({ flunk "FAILURE: Timed out!"; }));
 ok $lp-test, 'Passing an OSC message with LP+TCP worked.';


### PR DESCRIPTION
Hi. I wanted to communicate bi-directionally with SuperCollider, but Perl6's `IO::Socket::Async` does not yet allow user defined source ports which necessary to accomplish this. Adding TCP to your library was easier for me than adding user defined source ports to Rakudo, nqp and/or MoarVM :)

I did my best, but I am not sure how best to fit TCP into the design---Specifically, I'm not sure how to make a `Net::OSC::Client`. The code is functional, but if you want to give me some notes on how to align the design I could try to refactor and improve it.