### PR TITLE
Add `use experimental :pack`

### DIFF
--- a/lib/Net/OSC/Message.pm6
+++ b/lib/Net/OSC/Message.pm6
@@ -20,6 +20,7 @@ Set :is64bit to false to force messages to be packed to 32bit types
 =end pod
 
 use Numeric::Pack :ALL;
+use experimental :pack;
 
 my %type-map32 =
   Int.^name,    'i',


### PR DESCRIPTION
Message.pm6 is using experimental pack/unpack rakudo feature which
needs to be enabled with a pragma. Rakudo versions ≤ 2018.05 used to
give a run time error on first use, but starting with 2018.06 it will
be a compile time error. I think tests were never hitting the lines
with `pack` which is why tests were green previously.